### PR TITLE
Added version arg on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM centos:centos7
 MAINTAINER Apereo Foundation
 
 ENV PATH=$PATH:$JRE_HOME/bin
+ARG cas_version
 
 RUN yum -y install wget tar unzip git \
     && yum -y clean all
@@ -45,7 +46,7 @@ RUN cd / \
 
 # Download the CAS overlay project \
 RUN cd / \
-    && git clone --depth 1 --single-branch https://github.com/apereo/cas-overlay-template.git cas-overlay \
+    && git clone --depth 1 --single-branch -b $cas_version https://github.com/apereo/cas-overlay-template.git cas-overlay \
     && mkdir -p /etc/cas \
     && mkdir -p cas-overlay/bin;
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A docker image for CAS server. Images are tagged to match CAS server releases.
 ## Build [![](https://badge.imagelayers.io/apereo/cas:latest.svg)](https://imagelayers.io/?images=apereo/cas:latest 'apereo cas')
 
 **Make sure** that both `build.sh` and `run.sh` are updated to build the appropriate tag. Docker tags **MUST** correspond
-to CAS server versions.
+to CAS server versions. Also, make sure the version matches a branch name on the [CAS overlay project](https://github.com/apereo/cas-overlay-template/branches).
 
 **NOTE:** On windows, you may want to run `bash` first so you can execute shell scripts.
 

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ fi
 if [ ! -z "$cas_version" ]
   then
   	echo "Build CAS docker image tagged as v$cas_version"
-	docker build --tag="apereo/cas:v$cas_version" . && echo "Built CAS image successfully tagged as v$cas_version" && docker images "apereo/cas:v$cas_version"
+	docker build --tag="apereo/cas:v$cas_version" --build-arg cas_version=$cas_version . && echo "Built CAS image successfully tagged as v$cas_version" && docker images "apereo/cas:v$cas_version"
   else
   	echo "No image tag is provided."	
 fi


### PR DESCRIPTION
When building the Docker image, the Dockerfile was always pulling the master from the CAS Overlay Template instead of specific versions. As the latest versions use gradle instead of maven, the build would break.