### PR TITLE
clean up /root/.m2 directory after mvn command, which saves 160MB or so

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN set -x; \
     java_version=8.0.131; \
     zulu_version=8.21.0.1; \
     java_hash=1931ed3beedee0b16fb7fd37e069b162; \
-    
     cd / \
     && wget http://cdn.azul.com/zulu/bin/zulu$zulu_version-jdk$java_version-linux_x64.tar.gz \
     && echo "$java_hash  zulu$zulu_version-jdk$java_version-linux_x64.tar.gz" | md5sum -c - \
@@ -24,7 +23,7 @@ RUN cd / \
 	&& wget http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
     && unzip ZuluJCEPolicies.zip \
     && mv -f ZuluJCEPolicies/*.jar /opt/jre-home/lib/security \
-    && rm ZuluJCEPolicies.zip; 
+    && rm ZuluJCEPolicies.zip;
 
 
 # Set up Oracle Java properties
@@ -69,6 +68,6 @@ WORKDIR /cas-overlay
 ENV JAVA_HOME /opt/jre-home
 ENV PATH $PATH:$JAVA_HOME/bin:.
 
-RUN ./mvnw clean package -T 10
+RUN ./mvnw clean package -T 10 && rm -rf /root/.m2
 
 CMD ["/cas-overlay/bin/run-cas.sh"]


### PR DESCRIPTION
i ran this command in this repo before the pull request:

`docker build -t before`

and this with the changes from this pull request:

`docker build -t after`

in order to test for both the "before" and "after" cases, i added  `--branch 5.3` to the line in the Dockerfile that clones cas-overlay-template. https://github.com/apereo/cas-webapp-docker/pull/24 will resolve this.

image size results:

````
docker images --format '{{.Repository}} {{.Size}}' | head -2 | sort -r
before 985MB
after 823MB
````

i see that the last merged pull request (thanks, @mmoayyed !) on this repo was September 8, 2017, so I'm hoping that if someone sees this, they can hook it up! or perhaps we're filing pull requests against the wrong repo? i think this change is very low-risk. it will make docker builds that need to be derived from this base image slightly slower, since some of the libraries will have to be re-downloaded, but is almost certainly the right thing to do based on cleanup conventions i've seen in other Dockerfiles.